### PR TITLE
Add support for Chromebooks' Elan trackpad

### DIFF
--- a/VoodooI2CELAN/Info.plist
+++ b/VoodooI2CELAN/Info.plist
@@ -20,6 +20,22 @@
 	<string>1</string>
 	<key>IOKitPersonalities</key>
 	<dict>
+		<key>Elan Trackpad</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>me.kishorprins.VoodooI2CELAN</string>
+			<key>IOClass</key>
+			<string>VoodooI2CELANTouchpadDriver</string>
+			<key>IOProbeScore</key>
+			<integer>200</integer>
+			<key>IOPropertyMatch</key>
+			<dict>
+				<key>name</key>
+				<string>ELAN0000</string>
+			</dict>
+			<key>IOProviderClass</key>
+			<string>VoodooI2CDeviceNub</string>
+		</dict>
 		<key>VoodooI2CHIDDevice</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Chromebooks use ELAN0000 trackpad, which does not support HID over I2C (hence it doesn't match the 'compatible' property). Adding the hardware ID gets this device working.