### PR TITLE
Add polling configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Please refer to https://voodooi2c.github.io/#Installation/Installation.
 * ELAN0000
 * ELAN0100
 * ELAN0651
+* ELAN0626 (use Force Polling with polling interval set to 5 recommended, see Polling Configuration)
+
+## Polling Configuration
+Some trackpads may not work properly or at all with interrupt mode, even though it gets initialized successfully, that's why you may consider forcing polling. To force polling you need to open `VoodooI2CELAN.kext/Contents/Info.plist` in any editor and change `ForcePolling` to true.
+You may also want to change the polling interval, for that you'll need to edit `PollingInterval`, you can determine yours by trying out a couple different ones.
 
 *Note: Newer versions of the ELAN touchpads supports another protocol called Precision Touchpad (PTP). Touchpads implementing this protocol need to use VoodooI2CHID. An example of a ELAN based touchpad PTP is the ELAN1200.*
 

--- a/VoodooI2CELAN.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/VoodooI2CELAN.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/VoodooI2CELAN/Info.plist
+++ b/VoodooI2CELAN/Info.plist
@@ -39,6 +39,10 @@
 			<true/>
 			<key>QuietTimeAfterTyping</key>
 			<integer>500</integer>
+			<key>ForcePolling</key>
+			<false/>
+			<key>PollingInterval</key>
+			<integer>200</integer>
 		</dict>
 		<key>VoodooI2CHIDDevice</key>
 		<dict>
@@ -59,6 +63,10 @@
 			<true/>
 			<key>QuietTimeAfterTyping</key>
 			<integer>100</integer>
+			<key>ForcePolling</key>
+			<false/>
+			<key>PollingInterval</key>
+			<integer>200</integer>
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>

--- a/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
+++ b/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
@@ -176,6 +176,9 @@ class VoodooI2CELANTouchpadDriver : public IOService {
      */
     IOReturn message(UInt32 type, IOService* provider, void* argument) override;
     
+    uint32_t polling_interval;
+    bool force_polling;
+    bool setupPolling();
     void simulateInterrupt(OSObject* owner, IOTimerEventSource* timer);
 };
 


### PR DESCRIPTION
- Added forced polling support
- Added polling interval configuration
- Polling configuration docs

For some trackpads (like ELAN0626) interrupt mode initializes fine, but the trackpad is unusable due to extreme lag. That's why we may need to force polling in some cases.