### PR TITLE
Palm Rejection

### DIFF
--- a/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
+++ b/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
@@ -76,6 +76,9 @@ class VoodooI2CELANTouchpadDriver : public IOService {
     int pressure_adjustment;
     int product_id;
 
+    unsigned int width_per_trace_x;
+    unsigned int width_per_trace_y;
+
     IOInterruptEventSource* interrupt_source;
     VoodooI2CMultitouchInterface *mt_interface;
     OSArray* transducers;

--- a/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
+++ b/VoodooI2CELAN/VoodooI2CELANTouchpadDriver.hpp
@@ -36,7 +36,6 @@ class VoodooI2CELANTouchpadDriver : public IOService {
     OSDeclareDefaultStructors(VoodooI2CELANTouchpadDriver);
 
     VoodooI2CDeviceNub* api;
-    IOACPIPlatformDevice* acpi_device;
 
  public:
     /* Initialises the VoodooI2CELANTouchpadDriver object/instance (intended as IOKit driver ctor)
@@ -77,7 +76,6 @@ class VoodooI2CELANTouchpadDriver : public IOService {
     int pressure_adjustment;
     int product_id;
 
-    IOCommandGate* command_gate;
     IOInterruptEventSource* interrupt_source;
     VoodooI2CMultitouchInterface *mt_interface;
     OSArray* transducers;


### PR DESCRIPTION
Requires https://github.com/VoodooI2C/VoodooI2C/pull/547

Adds palm rejection based off of contact size. The Precision spec from Microsoft says contacts larger than 25mm should be marked as low confidence, which seems to work well with my touchpad on my Spin 713.

I also removed the command gate as the callback for the IOInterruptEventSource and IOTimerEventSource are already running in the workloop. This can be reverted pretty easily though if we want to keep the old implementation (I made it a separate commit).